### PR TITLE
Change Link to correct release name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Both the client and server are contained within the same binary.
 * The server (exit-node)
 
     ```sh
-    curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-    chmod +x ./inlets-pro-linux
+    curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+    chmod +x ./inlets-pro
     ```
 
 ## License

--- a/docs/caddy-tutorial.md
+++ b/docs/caddy-tutorial.md
@@ -11,9 +11,9 @@ Provision a VM on DigitalOcean or another IaaS provider.
 Log in with ssh and obtain the binary:
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-chmod +x ./inlets-pro-linux
-mv ./inlets-pro-linux /usr/bin/inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+chmod +x ./inlets-pro
+mv ./inlets-pro /usr/bin/inlets-pro
 ```
 
 Find your public IP:
@@ -85,9 +85,9 @@ python -m SimpleHTTPServer
 For a Linux client
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-chmod +x ./inlets-pro-linux
-mv ./inlets-pro-linux /usr/bin/inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+chmod +x ./inlets-pro
+mv ./inlets-pro /usr/bin/inlets-pro
 ```
 
 For a MacOS client

--- a/docs/cassandra-tutorial.md
+++ b/docs/cassandra-tutorial.md
@@ -11,9 +11,9 @@ Provision a VM on DigitalOcean or another IaaS provider.
 Log in with ssh and obtain the binary:
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-chmod +x ./inlets-pro-linux
-mv ./inlets-pro-linux /usr/bin/inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+chmod +x ./inlets-pro
+mv ./inlets-pro /usr/bin/inlets-pro
 ```
 
 Find your public IP:
@@ -57,15 +57,15 @@ Now run the inlets client on the other side:
 For a Linux client
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-chmod +x ./inlets-pro-linux
-mv ./inlets-pro-linux /usr/bin/inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+chmod +x ./inlets-pro
+mv ./inlets-pro /usr/bin/inlets-pro
 ```
 
 For a MacOS client
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-darwin > inlets-pro
 chmod +x ./inlets-pro
 sudo mv ./inlets-pro /usr/bin/inlets-pro
 ```

--- a/docs/ingress-tutorial.md
+++ b/docs/ingress-tutorial.md
@@ -59,8 +59,8 @@ Any VM is suitable, even a 5 USD DigitalOcean VM
 Download the `inlets-pro` binary on your VM.
 
 ```sh
-curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro-linux > inlets-pro-linux
-chmod +x ./inlets-pro-linux
+curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
+chmod +x ./inlets-pro
 ```
 
 Now run `tmux`, so that the binary stays running when you disconnect.
@@ -68,7 +68,7 @@ Now run `tmux`, so that the binary stays running when you disconnect.
 Now we will be proxying `nginxingress-nginx-ingress-controller` from within our Kubernetes cluster, so configure as follows:
 
 ```sh
-sudo ./inlets-pro-linux server \
+sudo ./inlets-pro server \
     --auto-tls \
     --common-name EXIT_NODE_IP \
     --remote-tcp nginxingress-nginx-ingress-controller \


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

The release binary name has changed to `inlets-pro` from `inlets-pro-linux`

Tested by running the commands. 

```
heyal@heyal-xps:~/go/src/github.com/inlets/inlets-pro-pkg$ curl -SLsf https://github.com/inlets/inlets-pro-pkg/releases/download/0.4.3/inlets-pro > inlets-pro
heyal@heyal-xps:~/go/src/github.com/inlets/inlets-pro-pkg$ chmod +x inlets-pro
heyal@heyal-xps:~/go/src/github.com/inlets/inlets-pro-pkg$ ./inlets-pro
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

PRO edition


        Tunnel TCP traffic at L4

Usage:
  inlets-pro [flags]
  inlets-pro [command]

Available Commands:
  client      Start the tunnel client.
  help        Help about any command
  server      Start the tunnel server.
  version     Display the clients version information.

Flags:
  -h, --help   help for inlets-pro

Use "inlets-pro [command] --help" for more information about a command.

```